### PR TITLE
[Feat/#4] API 헤더 타입 & 에러 대응

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,22 +1,15 @@
 import { useEffect, useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
-import { APIKit, ApiResponse } from './shared/http';
-
-interface GetAccountResponseDTO {
-  email: string;
-  name: string;
-  platform: string;
-}
+import { MyPageAPI } from './api/myPageAPI';
+import { GetAccountResponseDTO } from './api/dto/getAccountResponseDTO';
 
 function App() {
   const [account, setAccount] = useState<GetAccountResponseDTO | null>(null);
   useEffect(() => {
     async function fetchInfo() {
-      const resp = await APIKit.get<ApiResponse<GetAccountResponseDTO>>(
-        '/user/info',
-      );
-      setAccount(resp.data.data);
+      const data = await MyPageAPI.fetchInfo();
+      setAccount(data);
     }
 
     fetchInfo();

--- a/src/api/dto/getAccountResponseDTO.ts
+++ b/src/api/dto/getAccountResponseDTO.ts
@@ -1,0 +1,5 @@
+export interface GetAccountResponseDTO {
+  email: string;
+  name: string;
+  platform: string;
+}

--- a/src/api/myPageAPI.ts
+++ b/src/api/myPageAPI.ts
@@ -1,0 +1,13 @@
+import { createAPIRequest, HeaderType } from '../shared/http';
+import { GetAccountResponseDTO } from './dto/getAccountResponseDTO';
+
+export const MyPageAPI = {
+  fetchInfo: async (headerType: HeaderType = HeaderType.ACCESS_TOKEN) => {
+    const resp = await createAPIRequest<GetAccountResponseDTO>(
+      'get',
+      '/user/info',
+      headerType,
+    );
+    return resp.data.data;
+  },
+};

--- a/src/shared/http.ts
+++ b/src/shared/http.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { AxiosRequestConfig } from 'axios';
 import { BASE_URL } from '@env';
 
 export interface ApiResponse<T> {
@@ -7,19 +7,124 @@ export interface ApiResponse<T> {
   data: T;
 }
 
+export enum HeaderType {
+  SOCIAL_TOKEN = 'SOCIAL_TOKEN',
+  ACCESS_TOKEN = 'ACCESS_TOKEN',
+  REFRESH_TOKEN = 'REFRESH_TOKEN',
+  SIGN_UP = 'SIGN_UP',
+  WITH_TOKEN = 'WITH_TOKEN',
+}
+
+// UserManager 임시 구현
+class UserManager {
+  accessToken: string | null =
+    'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJpYXQiOjE3NjU1NTU5OTIsImV4cCI6MTc2Njc2NTU5MiwidHlwZSI6ImFjY2VzcyIsInVzZXJJZCI6Nzh9.m8emxbK_Ccnb6zgjRnNkzoPsHObjiMN_92bAjHL6QBuBGuTMRC5GhGMKYIj8IULsWAQZmtbZp0-k-DlSmQvySw';
+  refreshToken: string | null = null;
+  socialToken: string | null = null;
+}
+
+export const userManager = new UserManager();
+
+export const APIConstants = {
+  contentType: 'Content-Type',
+  applicationJSON: 'application/json',
+  auth: 'Authorization',
+  timeZone: 'Time-Zone',
+  seoul: 'Asia/Seoul',
+  OS: 'OS',
+  iOS: 'iOS',
+
+  get accessToken(): string {
+    return 'Bearer ' + (userManager.accessToken ?? '');
+  },
+
+  get refreshToken(): string {
+    return 'Bearer ' + (userManager.refreshToken ?? '');
+  },
+
+  get appleAccessToken(): string {
+    return userManager.socialToken ?? '';
+  },
+};
+
+export const getHeaders = (type: HeaderType): Record<string, string> => {
+  const { contentType, applicationJSON, auth, timeZone, seoul, OS, iOS } =
+    APIConstants;
+
+  switch (type) {
+    case HeaderType.SOCIAL_TOKEN:
+      return {
+        [contentType]: applicationJSON,
+        [auth]: APIConstants.appleAccessToken,
+      };
+
+    case HeaderType.WITH_TOKEN:
+      return {
+        [contentType]: applicationJSON,
+        [OS]: iOS,
+        [auth]: APIConstants.accessToken,
+        [timeZone]: seoul,
+      };
+
+    case HeaderType.ACCESS_TOKEN:
+      return {
+        [contentType]: applicationJSON,
+        [auth]: APIConstants.accessToken,
+        [timeZone]: seoul,
+      };
+
+    case HeaderType.REFRESH_TOKEN:
+      return {
+        [contentType]: applicationJSON,
+        [auth]: APIConstants.refreshToken,
+      };
+
+    case HeaderType.SIGN_UP:
+      return {
+        [contentType]: applicationJSON,
+        [auth]: APIConstants.appleAccessToken,
+        [OS]: iOS,
+        [timeZone]: seoul,
+      };
+
+    default:
+      return {
+        [contentType]: applicationJSON,
+      };
+  }
+};
+
 export const APIKit = axios.create({
   baseURL: BASE_URL,
   timeout: 30_000,
   timeoutErrorMessage: 'timeout',
 });
 
+export const createAPIRequest = <T>(
+  method: 'get' | 'post' | 'put' | 'delete' | 'patch',
+  url: string,
+  headerType: HeaderType,
+  data?: any,
+  config?: AxiosRequestConfig,
+) => {
+  const headers = getHeaders(headerType);
+
+  return APIKit.request<ApiResponse<T>>({
+    method,
+    url,
+    data,
+    headers: {
+      ...headers,
+      ...config?.headers,
+    },
+    ...config,
+  });
+};
+
 APIKit.interceptors.request.use(config => {
-  const token =
-    'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJpYXQiOjE3NjU1NTU5OTIsImV4cCI6MTc2Njc2NTU5MiwidHlwZSI6ImFjY2VzcyIsInVzZXJJZCI6Nzh9.m8emxbK_Ccnb6zgjRnNkzoPsHObjiMN_92bAjHL6QBuBGuTMRC5GhGMKYIj8IULsWAQZmtbZp0-k-DlSmQvySw';
-
-  config.headers?.set('Content-Type', 'application/json');
-  config.headers?.set('Authorization', 'Bearer ' + token);
-
+  if (!config.headers.get('Content-Type')) {
+    config.headers.set('Content-Type', 'application/json');
+  }
   return config;
 });
 

--- a/src/shared/http.ts
+++ b/src/shared/http.ts
@@ -7,6 +7,23 @@ export interface ApiResponse<T> {
   data: T;
 }
 
+export interface ApiErrorResponse {
+  status: number;
+  message: string;
+  data?: any;
+}
+
+export class ApiError extends Error {
+  constructor(
+    public status: number,
+    public message: string,
+    public data?: any,
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
 export enum HeaderType {
   SOCIAL_TOKEN = 'SOCIAL_TOKEN',
   ACCESS_TOKEN = 'ACCESS_TOKEN',
@@ -133,10 +150,37 @@ APIKit.interceptors.response.use(
     return response;
   },
   error => {
-    console.log('🔥 에러 발생');
-    console.log('URL:', error.config?.url);
-    console.log('Status:', error.response?.status);
-    console.log('Headers:', error.config?.headers);
-    console.log('Response data:', error.response?.data);
+    const status = error.response?.status || 500;
+    const message =
+      error.response?.data?.message || '알 수 없는 오류가 발생했습니다';
+    const data = error.response?.data;
+
+    const apiError = new ApiError(status, message, data);
+    handleApiError(apiError);
+
+    return Promise.reject(apiError);
   },
 );
+
+const handleApiError = (error: ApiError) => {
+  switch (error.status) {
+    case 400:
+      console.error('❌ 잘못된 요청:', error.message);
+      break;
+    case 401:
+      // TODO: refresh token 로직 필요
+      console.error('🔒 토큰 만료:', error.message);
+      break;
+    case 403:
+      console.error('🚫 권한 없음:', error.message);
+      break;
+    case 404:
+      console.error('🔍 리소스를 찾을 수 없음:', error.message);
+      break;
+    case 500:
+      console.error('💥 서버 오류:', error.message);
+      break;
+    default:
+      console.error('⚠️ API 오류:', error.message);
+  }
+};

--- a/src/shared/http.ts
+++ b/src/shared/http.ts
@@ -47,8 +47,10 @@ export const APIConstants = {
   applicationJSON: 'application/json',
   auth: 'Authorization',
   timeZone: 'Time-Zone',
+  // TODO: 현지화 대응 필요 (DeviceManager?)
   seoul: 'Asia/Seoul',
   OS: 'OS',
+  // TODO: OS 대응 필요 (DeviceManager?)
   iOS: 'iOS',
 
   get accessToken(): string {

--- a/src/shared/http.ts
+++ b/src/shared/http.ts
@@ -25,85 +25,82 @@ export class ApiError extends Error {
 }
 
 export enum HeaderType {
-  SOCIAL_TOKEN = 'SOCIAL_TOKEN',
+  AUTH_CODE = 'AUTH_CODE',
   ACCESS_TOKEN = 'ACCESS_TOKEN',
   REFRESH_TOKEN = 'REFRESH_TOKEN',
-  SIGN_UP = 'SIGN_UP',
-  WITH_TOKEN = 'WITH_TOKEN',
+  POST_DIARY = 'POST_DIARY',
+  TIME_ZONE = 'TIME_ZONE',
 }
 
 // UserManager 임시 구현
 class UserManager {
-  accessToken: string | null =
+  accessTokenValue: string =
     'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJpYXQiOjE3NjU1NTU5OTIsImV4cCI6MTc2Njc2NTU5MiwidHlwZSI6ImFjY2VzcyIsInVzZXJJZCI6Nzh9.m8emxbK_Ccnb6zgjRnNkzoPsHObjiMN_92bAjHL6QBuBGuTMRC5GhGMKYIj8IULsWAQZmtbZp0-k-DlSmQvySw';
-  refreshToken: string | null = null;
-  socialToken: string | null = null;
+  refreshTokenValue: string = '';
 }
 
 export const userManager = new UserManager();
+
+// LocalizationConstant 임시 구현
+class LocalizationConstant {
+  static timeZoneCode: string = 'Asia/Seoul';
+  static acceptLanguage: string = 'ko-KR';
+}
+
+export { LocalizationConstant };
 
 export const APIConstants = {
   contentType: 'Content-Type',
   applicationJSON: 'application/json',
   auth: 'Authorization',
+  access: 'accessToken',
+  refresh: 'refreshToken',
+  Bearer: 'Bearer ',
   timeZone: 'Time-Zone',
-  // TODO: 현지화 대응 필요 (DeviceManager?)
-  seoul: 'Asia/Seoul',
-  OS: 'OS',
-  // TODO: OS 대응 필요 (DeviceManager?)
-  iOS: 'iOS',
-
-  get accessToken(): string {
-    return 'Bearer ' + (userManager.accessToken ?? '');
-  },
-
-  get refreshToken(): string {
-    return 'Bearer ' + (userManager.refreshToken ?? '');
-  },
-
-  get appleAccessToken(): string {
-    return userManager.socialToken ?? '';
-  },
+  acceptLanguage: 'Accept-Language',
 };
 
 export const getHeaders = (type: HeaderType): Record<string, string> => {
-  const { contentType, applicationJSON, auth, timeZone, seoul, OS, iOS } =
-    APIConstants;
+  const {
+    contentType,
+    applicationJSON,
+    auth,
+    Bearer,
+    timeZone,
+    acceptLanguage,
+  } = APIConstants;
 
   switch (type) {
-    case HeaderType.SOCIAL_TOKEN:
+    case HeaderType.AUTH_CODE:
       return {
         [contentType]: applicationJSON,
-        [auth]: APIConstants.appleAccessToken,
-      };
-
-    case HeaderType.WITH_TOKEN:
-      return {
-        [contentType]: applicationJSON,
-        [OS]: iOS,
-        [auth]: APIConstants.accessToken,
-        [timeZone]: seoul,
+        [auth]: Bearer + userManager.accessTokenValue,
       };
 
     case HeaderType.ACCESS_TOKEN:
       return {
         [contentType]: applicationJSON,
-        [auth]: APIConstants.accessToken,
-        [timeZone]: seoul,
+        [auth]: Bearer + userManager.accessTokenValue,
       };
 
     case HeaderType.REFRESH_TOKEN:
       return {
-        [contentType]: applicationJSON,
-        [auth]: APIConstants.refreshToken,
+        [auth]: Bearer + userManager.refreshTokenValue,
       };
 
-    case HeaderType.SIGN_UP:
+    case HeaderType.POST_DIARY:
       return {
         [contentType]: applicationJSON,
-        [auth]: APIConstants.appleAccessToken,
-        [OS]: iOS,
-        [timeZone]: seoul,
+        [auth]: Bearer + userManager.accessTokenValue,
+        [timeZone]: LocalizationConstant.timeZoneCode,
+        [acceptLanguage]: LocalizationConstant.acceptLanguage,
+      };
+
+    case HeaderType.TIME_ZONE:
+      return {
+        [contentType]: applicationJSON,
+        [auth]: Bearer + userManager.accessTokenValue,
+        [timeZone]: LocalizationConstant.timeZoneCode,
       };
 
     default:


### PR DESCRIPTION
## Related issue 🛠
- closed #4 

## Work Description ✏️
- http 파일에서 헤더 및 에러 대응
- [ ] 헤더 대응
- [ ] 에러 대응

## To Reviewers 📢
```
export const MyPageAPI = {
  fetchInfo: async (headerType: HeaderType = HeaderType.ACCESS_TOKEN) => {
    const resp = await createAPIRequest<GetAccountResponseDTO>(
      'get',
      '/user/info',
      headerType,
    );
    return resp.data.data;
  },
};

```

api 파일에서 헤더 타입과 엔드 포인트를 다음과 같은 형식으로 작성하여 데이터를 반환할 수 있습니다.
또힌     resp.data.status로 status code를 불러와 필요한 분기처리를 할 수 있습니다.

공통 된 에러대응 (401 시 재발급) 같은 로직은 추후 http 안에 구현해야할 것 같습니다.